### PR TITLE
Script to Remove duplicate rows from bigquery table #4953

### DIFF
--- a/flows/remove-duplicates-in-bq.sh
+++ b/flows/remove-duplicates-in-bq.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eu
+
+project="$1"
+dataset="$2"
+table="$3"
+unique_field="$4"
+order_field="$5"
+
+
+SQL="DELETE FROM \`{project}.{dataset}.{table}\` WHERE STRUCT({unique_field}, {order_field}) NOT IN (SELECT AS STRUCT {unique_field}, MAX({order_field})  FROM \`{project}.{dataset}.{table}\`  GROUP BY {unique_field})"
+SQL=$(sed -e "s/{project}/"$project"/g" <<< $SQL)
+SQL=$(sed -e "s/{dataset}/"$dataset"/g" <<< $SQL)
+SQL=$(sed -e "s/{table}/"$table"/g" <<< $SQL)
+SQL=$(sed -e "s/{unique_field}/"$unique_field"/g" <<< $SQL)
+SQL=$(sed -e "s/{order_field}/"$order_field"/g" <<< $SQL)
+SQL=$(sed -e "s/\`/\\\\\`/g" <<< $SQL)
+
+sudo -u elife --login /bin/bash << EOF
+bq query --nouse_legacy_sql "$SQL"
+EOF


### PR DESCRIPTION
Add script that can be used to remove duplicate rows from bigquery tables based on the unique keys and imported_timestamp.
To be executed by nifi processor for People and Profile Import ( https://github.com/elifesciences/issues/issues/4953 ) after every full/complete big query table data import.
@lsh-0 , @de-code - i am actually wondering if this is really to a certain degree safe to do. If you feel very strongly against it, I can choose not to use this implementation